### PR TITLE
Add country code config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,13 +51,18 @@ add the following to `app/src/main/res/values/strings.xml`:
 <string name="app_update_install">RESTART</string>
 ```
 
-#### Required Parameters
+Configuration Preferences
+------------
 
-Due to Siren's implementation, if your application is not available on the US appstore please specify a country code.
+Non US-AppStore iOS apps
+
+Siren's implementation for iOS requires specifying a country code if your app is not published to the US AppStore.
 
 ```xml
-<preference name="SirenCountryCode" value="CA"/>
+<preference name="SirenCountryCode" value="CA" />
 ```
+
+For Capacitor, add `"SirenCountryCode": "CA"` to your capacitor.config.json file.
 
 
 Supported Platforms

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ add the following to `app/src/main/res/values/strings.xml`:
 Configuration Preferences
 ------------
 
-Non US-AppStore iOS apps
+### Non US-AppStore iOS apps
 
 Siren's implementation for iOS requires specifying a country code if your app is not published to the US AppStore.
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ add the following to `app/src/main/res/values/strings.xml`:
 <string name="app_update_install">RESTART</string>
 ```
 
+#### Required Parameters
+
+Due to Siren's implementation, if your application is not available on the US appstore please specify a country code.
+
+```xml
+<preference name="SirenCountryCode" value="CA"/>
+```
+
 
 Supported Platforms
 -------------------

--- a/src/ios/UpdateNotifierPlugin.swift
+++ b/src/ios/UpdateNotifierPlugin.swift
@@ -28,6 +28,12 @@ class UpdateNotifierPlugin : CDVPlugin {
 
 
     @objc internal func _didFinishLaunchingWithOptions(_ notification : NSNotification) {
-        Siren.shared.wail()
+        let siren = Siren.shared
+
+        if let countryCode = self.commandDelegate.settings["sirencountrycode"] as? String {
+            siren.apiManager = APIManager(countryCode: countryCode)
+        }
+
+        siren.wail()
     }
 }


### PR DESCRIPTION
*  Due to Siren's implementation, if a user's application is not published on the US appstore Siren will fail to find the application. To resolve this we add support for a config variable `SirenCountryCode` which will configure Siren to search for your application in the specified appstore region.
*  It may also be useful to provide config variables for some if not all of the siren rules to allow further customization whilst using this plugin.