### PR TITLE
Various Android fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,17 @@ Configuration Preferences
 
 ### Alert Type
 
-Siren's implementation for iOS allows for different alert types (see https://github.com/ArtSabintsev/Siren#screenshots). You can set the value to "critical" or "annyoing" in config.xml.
+Siren's implementation for iOS allows for different alert types (see https://github.com/ArtSabintsev/Siren#screenshots). You can set the value to "critical" or "annoying" in config.xml.
 
 ```xml
 <preference name="SirenAlertType" value="critical" />
 <preference name="SirenAlertType" value="annoying" />
+```
+
+For Android, you can force all updates to be considered "immediate" with the `AndroidUpdateAlertType` preference in config.xml.
+
+```xml
+<preference name="AndroidUpdateAlertType" value="Immediate" />
 ```
 
 ### Non US-AppStore iOS apps

--- a/src/android/UpdateNotifierPlugin.java
+++ b/src/android/UpdateNotifierPlugin.java
@@ -41,6 +41,7 @@ import static android.app.Activity.RESULT_OK;
 public class UpdateNotifierPlugin extends CordovaPlugin {
     private AppUpdateManager mAppUpdateManager;
     private InstallStateUpdatedListener mInstallListener;
+    private Boolean mHasPrompted = false;
 
     private final String TAG = "UpdateNotifierPlugin";
     private static final Integer RC_APP_UPDATE = 577;
@@ -79,6 +80,10 @@ public class UpdateNotifierPlugin extends CordovaPlugin {
         mAppUpdateManager = AppUpdateManagerFactory.create(cordova.getActivity());
         mAppUpdateManager.registerListener(mInstallListener);
 
+        if (mHasPrompted == true) {
+            return;
+        }
+
         Task<AppUpdateInfo> appUpdateInfoTask = mAppUpdateManager.getAppUpdateInfo();
 
         appUpdateInfoTask.addOnSuccessListener(new OnSuccessListener<AppUpdateInfo>() {
@@ -103,6 +108,7 @@ public class UpdateNotifierPlugin extends CordovaPlugin {
                 }
             }
         });
+        mHasPrompted = true;
     }
 
     /**

--- a/src/android/UpdateNotifierPlugin.java
+++ b/src/android/UpdateNotifierPlugin.java
@@ -86,10 +86,12 @@ public class UpdateNotifierPlugin extends CordovaPlugin {
 
         Task<AppUpdateInfo> appUpdateInfoTask = mAppUpdateManager.getAppUpdateInfo();
 
+        final Boolean forceImmediate = preferences.getString("androidupdatealerttype", "").equalsIgnoreCase("immediate");
+
         appUpdateInfoTask.addOnSuccessListener(new OnSuccessListener<AppUpdateInfo>() {
             @Override
             public void onSuccess(AppUpdateInfo appUpdateInfo) {
-                if (appUpdateInfo.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE && appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE)) {
+                if (!forceImmediate && appUpdateInfo.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE && appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE)) {
                     try {
                         mAppUpdateManager.startUpdateFlowForResult(appUpdateInfo, AppUpdateType.FLEXIBLE, cordova.getActivity(), RC_APP_UPDATE);
                     } catch (IntentSender.SendIntentException e) {

--- a/src/android/UpdateNotifierPlugin.java
+++ b/src/android/UpdateNotifierPlugin.java
@@ -89,15 +89,15 @@ public class UpdateNotifierPlugin extends CordovaPlugin {
         appUpdateInfoTask.addOnSuccessListener(new OnSuccessListener<AppUpdateInfo>() {
             @Override
             public void onSuccess(AppUpdateInfo appUpdateInfo) {
-                if (appUpdateInfo.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE && appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.IMMEDIATE)) {
+                if (appUpdateInfo.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE && appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE)) {
                     try {
-                        mAppUpdateManager.startUpdateFlowForResult(appUpdateInfo, AppUpdateType.IMMEDIATE, cordova.getActivity(), RC_APP_UPDATE);
+                        mAppUpdateManager.startUpdateFlowForResult(appUpdateInfo, AppUpdateType.FLEXIBLE, cordova.getActivity(), RC_APP_UPDATE);
                     } catch (IntentSender.SendIntentException e) {
                         e.printStackTrace();
                     }
-                } else if (appUpdateInfo.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE && appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.FLEXIBLE)) {
+                } else if (appUpdateInfo.updateAvailability() == UpdateAvailability.UPDATE_AVAILABLE && appUpdateInfo.isUpdateTypeAllowed(AppUpdateType.IMMEDIATE)) {
                     try {
-                        mAppUpdateManager.startUpdateFlowForResult(appUpdateInfo, AppUpdateType.FLEXIBLE, cordova.getActivity(), RC_APP_UPDATE);
+                        mAppUpdateManager.startUpdateFlowForResult(appUpdateInfo, AppUpdateType.IMMEDIATE, cordova.getActivity(), RC_APP_UPDATE);
                     } catch (IntentSender.SendIntentException e) {
                         e.printStackTrace();
                     }


### PR DESCRIPTION
* Fixes a case where immediate updates (which show a fullscreen overlay) were prompting continuously (#9)
* Fixes that all updates were being shown as immediate fullscreen overlays instead of defaulting to flexible (popup dialog)
* Now that updates are flexible by default, add a preference to force them to be immediate