### PR TITLE
[Android] Use AndroidX (for next major)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-  Copyright 2020 Ayogo Health Inc.
+  Copyright 2020-2021 Ayogo Health Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -23,6 +23,10 @@ version of the app is available for download from the App Store or Play Store.
 For iOS, this uses the [Siren][siren] library.
 
 For Android, this implements the [Play Store In-App Update][playlib] system.
+
+> ℹ️ **This plugin uses AndroidX!**
+>
+> Use version 1.x if you are building without AndroidX enabled.
 
 
 Installation
@@ -89,7 +93,7 @@ Supported Platforms
 
 * **Cordova CLI** (cordova-cli >= 9.0.0)
 * **iOS** (cordova-ios >= 5.0.0, or capacitor)
-* **Android** (cordova-android >= 8.0.0, or capacitor)
+* **Android** (cordova-android >= 9.0.0, or capacitor) with AndroidX
 
 
 Contributing
@@ -107,7 +111,7 @@ Licence
 -------
 
 Released under the Apache 2.0 Licence.  
-Copyright © 2020 Ayogo Health Inc.
+Copyright © 2020-2021 Ayogo Health Inc.
 
 [siren]: https://sabintsev.com/Siren/
 [playlib]: https://developer.android.com/guide/playcore/in-app-updates

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "engines": [
     {
       "name": "cordova-android",
-      "version": ">= 8.0.0"
+      "version": ">= 9.0.0"
     },
     {
       "name": "cordova-ios",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright 2020 Ayogo Health Inc.
+Copyright 2020-2021 Ayogo Health Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ limitations under the License.
 
   <engines>
     <engine name="cordova-ios" version=">= 5.0.0" />
-    <engine name="cordova-android" version=">= 8.0.0" />
+    <engine name="cordova-android" version=">= 9.0.0" />
   </engines>
 
   <platform name="ios">
@@ -63,7 +63,7 @@ limitations under the License.
       <string name="app_update_install">RESTART</string>
     </config-file>
 
-    <framework src="com.android.support:design:[26.0.0,)" />
+    <framework src="com.google.android.material:material:[1.0.0,)" />
     <framework src="com.google.android.play:core:[1.5,2)" />
   </platform>
 </plugin>

--- a/src/android/UpdateNotifierPlugin.java
+++ b/src/android/UpdateNotifierPlugin.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020 Ayogo Health Inc.
+ * Copyright 2020-2021 Ayogo Health Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ package com.ayogo.cordova.updatenotifier;
 import android.app.Activity;
 import android.content.Intent;
 import android.content.IntentSender;
-import android.support.design.widget.Snackbar;
+import com.google.android.material.snackbar.Snackbar;
 import android.view.View;
 
 import org.apache.cordova.CordovaPlugin;


### PR DESCRIPTION
Bump minimum cordova-android version to 9, because that's when the AndroidX preference was introduced.