### PR TITLE
[android] Fix material library breaking builds

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -63,7 +63,7 @@ limitations under the License.
       <string name="app_update_install">RESTART</string>
     </config-file>
 
-    <framework src="com.google.android.material:material:[1.0.0,)" />
+    <framework src="com.google.android.material:material:[1.0.0,1.5.0)" />
     <framework src="com.google.android.play:core:[1.5,2)" />
   </platform>
 </plugin>


### PR DESCRIPTION
The 1.5.0-alpha03 version of Google's material library has a dependency on Android SDK 31 and causes AAPT build failures with older SDKs. Cordova's latest Android release uses SDK 30, so we don't want to require SDK 31 yet.