### PR TITLE
Update to support Android SDK 34

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright 2020-2021 Ayogo Health Inc.
+Copyright 2020-2023 Ayogo Health Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -54,6 +54,8 @@ limitations under the License.
         <param name="android-package" value="com.ayogo.cordova.updatenotifier.UpdateNotifierPlugin" />
         <param name="onload" value="true" />
       </feature>
+
+      <preference name="AndroidXEnabled" value="true" />
     </config-file>
 
     <source-file src="src/android/UpdateNotifierPlugin.java" target-dir="src/com/ayogo/cordova/updatenotifier" />
@@ -63,7 +65,10 @@ limitations under the License.
       <string name="app_update_install">RESTART</string>
     </config-file>
 
-    <framework src="com.google.android.material:material:[1.0.0,1.5.0)" />
-    <framework src="com.google.android.play:core:[1.5,2)" />
+    <preference name="ANDROIDX_MATERIAL_DESIGN_VERSION" default="[1.0,2)" />
+    <preference name="PLAY_APP_UPDATE_SDK_VERSION" default="[2.0,3)" />
+
+    <framework src="com.google.android.material:material:$ANDROIDX_MATERIAL_DESIGN_VERSION" />
+    <framework src="com.google.android.play:app-update:$PLAY_APP_UPDATE_SDK_VERSION" />
   </platform>
 </plugin>

--- a/src/android/UpdateNotifierPlugin.java
+++ b/src/android/UpdateNotifierPlugin.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2020-2021 Ayogo Health Inc.
+ * Copyright 2020-2023 Ayogo Health Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,8 +33,8 @@ import com.google.android.play.core.install.InstallStateUpdatedListener;
 import com.google.android.play.core.install.model.AppUpdateType;
 import com.google.android.play.core.install.model.InstallStatus;
 import com.google.android.play.core.install.model.UpdateAvailability;
-import com.google.android.play.core.tasks.OnSuccessListener;
-import com.google.android.play.core.tasks.Task;
+import com.google.android.gms.tasks.OnSuccessListener;
+import com.google.android.gms.tasks.Task;
 
 import static android.app.Activity.RESULT_OK;
 


### PR DESCRIPTION
This is required to support Android SDK 34, but has the side effect of not (by default) being compatible with any SDK version lower than 34 because Google aggressively pushes AndroidX updates that require newer APIs.

To overcome this, the gradle dependency versions are now pulled out into install variables, so you can do something like this to get a working version for the SDK that you're targeting:
```
npx cordova plugin add cordova-plugin-update-notifier \
    --variable ANDROIDX_MATERIAL_DESIGN_VERSION=1.8.0
```

Because this causes breakage, it'll have to be a major version bump and have some documentation added to the README about it.

Fixes #23.